### PR TITLE
Missing Documentation for Generating Laravel Application Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ npm run dev
 ```shell
 $ cp .env.example .env
 $ composer install
+$ php artisan key:generate
 $ php artisan serve
 ```
 


### PR DESCRIPTION
## Description

I discovered that the project currently lacks a proper instruction to generate an application key using the `php artisan key:generate` command. This is a crucial step for Laravel applications, and its absence in the documentation could lead to confusion for new contributors or users.

## Suggested Improvement

I propose updating the README file or documentation to include a section explaining the importance of generating an application key and providing the necessary command:

`php artisan key:generate`